### PR TITLE
DDS-1218-queue-publisher

### DIFF
--- a/app.local.env
+++ b/app.local.env
@@ -1,0 +1,2 @@
+AMQP_URL=amqp://guest:guest@rabbitmq.host:5672
+TASK_QUEUE_NAME=file_versions

--- a/dds_md5_publisher.rb
+++ b/dds_md5_publisher.rb
@@ -1,0 +1,51 @@
+#!/usr/local/bin/ruby
+
+class DdsMd5Publisher
+  require "bunny"
+
+  attr_accessor :connection, :channel, :exchange
+  def initialize(connection=nil)
+    if connection
+      @connection = connection
+    end
+    connect
+  end
+
+  def publish_file_version_id(id)
+    @exchange.publish(id, routing_key: ENV['TASK_QUEUE_NAME'])
+  end
+
+  def publish_file_version_ids_from(io)
+    while (id = io.gets)
+      publish_file_version_id(id.chomp)
+    end
+  end
+
+  private
+  def connect
+    unless @connection
+      @connection = Bunny.new(ENV['AMQP_URL'], automatically_recover: false)
+    end
+    @connection.start
+    @channel = @connection.create_channel
+    @exchange = @channel.default_exchange
+  end
+end
+
+def usage
+  $stderr.puts "usage: dds_md5_publisher <path_to_file_with_ids_one_per_line>
+  requires the following Environment Variables
+    AMQP_URL: full url to amqp service
+    TASK_QUEUE_NAME: name of queue used by the dds_md5_subscriber.rb script
+  "
+  exit(1)
+end
+
+if $0 == __FILE__
+  input_file = ARGV.shift or die usage
+  die usage unless(ENV['AMQP_URL'] && ENV['TASK_QUEUE_NAME'])
+  File.open(input_file, 'r') do |id_file|
+    DdsMd5Publisher.new.publish_file_version_ids_from id_file
+  end
+  $stderr.puts "all published"
+end

--- a/spec/dds_md5_publisher_spec.rb
+++ b/spec/dds_md5_publisher_spec.rb
@@ -1,0 +1,56 @@
+require_relative '../dds_md5_publisher'
+require 'bunny-mock'
+
+describe DdsMd5Publisher do
+  let(:mocked_bunny) { BunnyMock.new }
+  subject {
+    DdsMd5Publisher.new mocked_bunny
+  }
+
+  it { is_expected.to respond_to(:publish_file_version_id).with(1).argument }
+  it { is_expected.to respond_to(:publish_file_version_ids_from).with(1).argument }
+
+  describe '#publish_file_version_id' do
+    let(:id_to_publish) { 'id-to-publish' }
+    let(:task_queue) {
+      subject.channel.queue(ENV['TASK_QUEUE_NAME'], durable: true)
+    }
+
+    it 'should publish the id to the task queue' do
+      expect(task_queue).to be
+      # the bunny-mock default exchange is a standard BunnyMock::Exchange::Direct
+      # so a BunnyMock::Queue has to be manually bound to that exchange
+      # before running the test
+      task_queue.bind subject.exchange, routing_key: task_queue.name
+      subject.publish_file_version_id id_to_publish
+      expect(task_queue.message_count).to eq(1)
+      payload = task_queue.all.first
+      expect(payload[:message]).to eq(id_to_publish)
+    end
+  end
+
+  describe '#publish_file_version_ids_from' do
+    let(:ids) { [
+        'id-1',
+        'id-2'
+    ] }
+    let(:io_to_publish) {
+      io = StringIO.new("")
+      ids.each do |id|
+        io.puts id
+      end
+      io.rewind
+      io
+    }
+
+    before do
+      ids.each do |id|
+        is_expected.to receive(:publish_file_version_id)
+          .with(id)
+      end
+    end
+    it 'should publish all ids' do
+      subject.publish_file_version_ids_from io_to_publish
+    end
+  end
+end


### PR DESCRIPTION
application that takes a file of ids and publishes them to the queue used by the dds_md5_subscriber
