### PR TITLE
DDS-1218-memory_profiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gem 'activesupport', '~> 5.0'
 
 gem 'sneakers'
 gem 'bunny-mock'
+
+gem 'memory_profiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    memory_profiler (0.9.14)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
@@ -58,6 +59,7 @@ DEPENDENCIES
   activesupport (~> 5.0)
   bunny-mock
   httparty
+  memory_profiler
   rspec
   sneakers
 

--- a/dds_md5_reporter.rb
+++ b/dds_md5_reporter.rb
@@ -164,6 +164,7 @@ class DdsMd5Reporter
     }.each do |chunk_summary|
       upload_digest << chunk_text(chunk_summary, chunk_start)
       chunk_start += chunk_summary["size"].to_i
+      GC.start if ENV['COLLECT_GARBAGE']
     end
     upload_digest.hexdigest
   end
@@ -194,13 +195,15 @@ end
 if $0 == __FILE__
   file_version_id = ARGV.shift or usage()
   begin
+    report_started = Time.now.to_i
     DdsMd5Reporter.new(
       file_version_id: file_version_id,
       user_key: ENV['USER_KEY'],
       agent_key: ENV['AGENT_KEY'],
       dds_api_url: ENV['DDS_API_URL']
     ).report_md5
-    puts "md5 reported"
+    report_time = Time.now.to_i - report_started
+    puts "md5 reported in #{report_time} seconds"
   rescue ArgumentError => e
     $stderr.puts "#{e.message}"
     usage()

--- a/dds_md5_reporter.rb
+++ b/dds_md5_reporter.rb
@@ -164,7 +164,7 @@ class DdsMd5Reporter
     }.each do |chunk_summary|
       upload_digest << chunk_text(chunk_summary, chunk_start)
       chunk_start += chunk_summary["size"].to_i
-      GC.start if ENV['COLLECT_GARBAGE']
+      GC.start
     end
     upload_digest.hexdigest
   end

--- a/dds_md5_subscriber.rb
+++ b/dds_md5_subscriber.rb
@@ -32,7 +32,12 @@ class DdsMd5Subscriber
       if ENV['PROFILE_MEMORY']
         report = MemoryProfiler.stop
         logger.info("printing memory profile report")
-        report.pretty_print(scale_bytes: true)
+        report.pretty_print(
+          scale_bytes: true,
+          retained_strings: 0,
+          allocated_strings: 0,
+          normalize_paths: true
+        )
       end
     rescue StandardError => e
       logger.error(e.message)

--- a/dds_md5_subscriber.rb
+++ b/dds_md5_subscriber.rb
@@ -3,7 +3,6 @@ require 'sneakers'
 require 'sneakers/runner'
 require 'sneakers/handlers/maxretry'
 require 'logger'
-require 'memory_profiler' if ENV['PROFILE_MEMORY']
 
 class DdsMd5Subscriber
   require_relative 'dds_md5_reporter'

--- a/dds_md5_subscriber.rb
+++ b/dds_md5_subscriber.rb
@@ -19,9 +19,6 @@ class DdsMd5Subscriber
     logger.info("processing file_version_id: #{file_version_id}")
     has_error = false
     begin
-      if ENV['PROFILE_MEMORY']
-        MemoryProfiler.start
-      end
       report_started = Time.now.to_i
       DdsMd5Reporter.new(
         file_version_id: file_version_id,
@@ -31,16 +28,6 @@ class DdsMd5Subscriber
       ).report_md5
       report_time = Time.now.to_i - report_started
       logger.info("md5 reported in #{report_time} seconds!")
-      if ENV['PROFILE_MEMORY']
-        report = MemoryProfiler.stop
-        logger.info("printing memory profile report")
-        report.pretty_print(
-          scale_bytes: true,
-          retained_strings: 0,
-          allocated_strings: 0,
-          normalize_paths: true
-        )
-      end
     rescue StandardError => e
       logger.error(e.message)
       has_error = true

--- a/dds_md5_subscriber.rb
+++ b/dds_md5_subscriber.rb
@@ -22,13 +22,15 @@ class DdsMd5Subscriber
       if ENV['PROFILE_MEMORY']
         MemoryProfiler.start
       end
+      report_started = Time.now.to_i
       DdsMd5Reporter.new(
         file_version_id: file_version_id,
         user_key: ENV['USER_KEY'],
         agent_key: ENV['AGENT_KEY'],
         dds_api_url: ENV['DDS_API_URL']
       ).report_md5
-      logger.info("md5 reported!")
+      report_time = Time.now.to_i - report_started
+      logger.info("md5 reported in #{report_time} seconds!")
       if ENV['PROFILE_MEMORY']
         report = MemoryProfiler.stop
         logger.info("printing memory profile report")


### PR DESCRIPTION
commits contain use of features flags to profile memory using the memory_profiler gem, and the use of GC.start. Ultimately, it was determined that a well placed GC.start in the dds_md5_reporter reduced overall memory utilization during the processing of larger files.